### PR TITLE
fix: Proper connection string

### DIFF
--- a/dbus-mqtt-grid/dbus-mqtt-grid.py
+++ b/dbus-mqtt-grid/dbus-mqtt-grid.py
@@ -309,7 +309,7 @@ class DbusMqttGridService:
         paths,
         productname="MQTT Grid",
         customname="MQTT Grid",
-        connection="MQTT Grid service",
+        connection="VE.Bus",
     ):
         self._dbusservice = VeDbusService(servicename)
         self._paths = paths


### PR DESCRIPTION
Doesn't work with default one
Not sure yet which one should be for getting it in Energy Meters submenu
![image](https://github.com/mr-manuel/venus-os_dbus-mqtt-grid/assets/563412/0ae58e25-3ec4-4ae1-b5c7-53756e0c5a95)
![image](https://github.com/mr-manuel/venus-os_dbus-mqtt-grid/assets/563412/463da6d6-409f-4f3f-a508-16f74710e370)
