### PR TITLE
ESPHome adaptation instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ See also this [comment](https://github.com/mr-manuel/venus-os_dbus-mqtt-grid/iss
 
 ### ESPHome
 
-If you have working setup with any esphome-p1reader fork e.g. [here](https://github.com/mp314/esphome-p1reader), you can add direct connection to Victorn MQTT server and bypass the HA instance.
+If you have working setup with esphome-p1reader e.g. [here](https://github.com/mp314/esphome-p1reader), you can add direct connection to Victor MQTT server and bypass the HA run time dependency.
 
-Just add mqtt-broker, `id` -field to every sensor, and mqtt.publish_json to last sensor value (in my case "Cumulative Active Import", CRC ok event would be more correct place). See example below. 
+Just add mqtt-broker, id-field to every sensor, and mqtt.publish_json to last updated sensor value (in this case "Cumulative Active Import", CRC ok event would be more correct place). See example below. 
 
 ```yml
 mqtt:
@@ -234,6 +234,8 @@ sensor:
       # id added
       id: E_out
 ```
+
+Note: This example sends all mqtt messages to Victron server, so there is some extra traffic.
 
 ### Shelly (Gen 2+)
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 1. [JSON structure](#json-structure)
     - [Generic device](#generic-device)
     - [Home Assistant](#home-assistant)
+    - [ESPHome](#esphome)
     - [Shelly Gen2+](#shelly-gen-2)
     - [Tasmota](#tasmota)
 1. [Install / Update](#install--update)


### PR DESCRIPTION
Thanks for great projects @mr-manuel :)

Added ESPHome configuration example to bypass HA runtime dependency. ESPHome can send the P1/HAN (smart meter) info directly MQTT, in the format that dbus-mqtt-grid can understand.

I think this could be covered also in some discussion forum, if you think this is too much off topic.. 

Tested: "works for me" :) below full yaml.

```yml
substitutions:
  device_description: "Monitor HAN port and provide the data to HA and Victron"

esphome:
  name: esp-p1reader
  friendly_name: Esp-P1Reader
  comment: ${device_description}

esp8266:
  board: nodemcu # esp01_1m

# Enable logging
logger:
  level: INFO  # Logging costs performnce, swithc to DEBUG when needed
  baud_rate: 0 # disable logging over uart (would use up a HW uart)
  esp8266_store_log_strings_in_flash: false # Avoid flash wear and tear

# Enable Home Assistant API
api:
  encryption:
    key: "Kvuqxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1Xwk="

ota:
  - platform: esphome
    password: !secret ota_password

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
  domain: .esp

  # Enable fallback hotspot (captive portal) in case wifi connection fails
  ap:
    ssid: "Esp-P1Reader Fallback Hotspot"
    password: !secret fallback_password

captive_portal:

mqtt:
  broker: !secret victron_mqtt

external_components:
  - source:
      type: git
      url: https://github.com/mp314/esphome-p1reader
      # Works with hw described here: https://github.com/rainisto/esphome-p1reader , yaml syntax is different
    components: [ p1reader ]


uart:
  id: uart_bus
  tx_pin: TX
  rx_pin: RX
  baud_rate: 115200
  rx_buffer_size: 3072    # UART Buffer size controls polling frequency

p1reader:
  - id: p1reader_esp
    uart_id: uart_bus
#  Size of the internal working buffer (default 60)
#    buffer_size: 3072
#    protocol: hdlc
#  OR (the default if left unset)
#    protocol: ascii

sensor:
  - platform: p1reader
    p1reader_id: p1reader_esp
    cumulative_active_import:
      name: "Cumulative Active Import"
      id: E_in
      on_value:
        then:
          - mqtt.publish_json:
              topic: "han/p1reader"
              payload: |-
                root["grid"]["power"] = (id(P_in).state-id(P_out).state) * 1000;
                root["grid"]["energy_forward"] = id(E_in).state;
                root["grid"]["energy_reverse"] = id(E_out).state;
                root["grid"]["L1"]["power"] = (id(P1_in).state-id(P1_out).state) * 1000;
                root["grid"]["L2"]["power"] = (id(P2_in).state-id(P2_out).state) * 1000;
                root["grid"]["L3"]["power"] = (id(P3_in).state-id(P3_out).state) * 1000;
                root["grid"]["L1"]["voltage"] = id(U1).state;
                root["grid"]["L2"]["voltage"] = id(U2).state;
                root["grid"]["L3"]["voltage"] = id(U3).state;
                root["grid"]["L1"]["current"] = id(I1).state;
                root["grid"]["L2"]["current"] = id(I1).state;
                root["grid"]["L3"]["current"] = id(I3).state;

  - platform: p1reader
    p1reader_id: p1reader_esp
    cumulative_active_export:
      name: "Cumulative Active Export"
      id: E_out

#  - platform: p1reader
#    p1reader_id: p1reader_esp
#    cumulative_reactive_import:
#      name: "Cumulative Reactive Import"

#  - platform: p1reader
#    p1reader_id: p1reader_esp
#    cumulative_reactive_export:
#      name: "Cumulative Reactive Export"

  - platform: p1reader
    p1reader_id: p1reader_esp
    momentary_active_import:
      name: "Momentary Active Import"
      id: P_in
 
  - platform: p1reader
    p1reader_id: p1reader_esp
    momentary_active_export:
      name: "Momentary Active Export"
      id: P_out

#  - platform: p1reader
#    p1reader_id: p1reader_esp
#    momentary_reactive_import:
#      name: "Momentary Reactive Import"

#  - platform: p1reader
#    p1reader_id: p1reader_esp
#    momentary_reactive_export:
#      name: "Momentary Reactive Export"

  - platform: p1reader
    p1reader_id: p1reader_esp
    momentary_active_import_l1:
      name: "Momentary Active Import Phase 1"
      id: P1_in

  - platform: p1reader
    p1reader_id: p1reader_esp
    momentary_active_export_l1:
      name: "Momentary Active Export Phase 1"
      id: P1_out
 
  - platform: p1reader
    p1reader_id: p1reader_esp
    momentary_active_import_l2:
      name: "Momentary Active Import Phase 2"
      id: P2_in

  - platform: p1reader
    p1reader_id: p1reader_esp
    momentary_active_export_l2:
      name: "Momentary Active Export Phase 2"
      id: P2_out

  - platform: p1reader
    p1reader_id: p1reader_esp
    momentary_active_import_l3:
      name: "Momentary Active Import Phase 3"
      id: P3_in

  - platform: p1reader
    p1reader_id: p1reader_esp
    momentary_active_export_l3:
      name: "Momentary Active Export Phase 3"
      id: P3_out

#  - platform: p1reader
#    p1reader_id: p1reader_esp
#    momentary_reactive_import_l1:
#      name: "Momentary Reactive Import Phase 1"

#  - platform: p1reader
#    p1reader_id: p1reader_esp
#    momentary_reactive_import_l2:
#      name: "Momentary Reactive Import Phase 2"

 # - platform: p1reader
 #   p1reader_id: p1reader_esp
 #   momentary_reactive_import_l3:
 #     name: "Momentary Reactive Import Phase 3"

 # - platform: p1reader
 #   p1reader_id: p1reader_esp
 #   momentary_reactive_export_l1:
 #     name: "Momentary Reactive Export Phase 1"

#  - platform: p1reader
#    p1reader_id: p1reader_esp
#    momentary_reactive_export_l2:
#      name: "Momentary Reactive Export Phase 2"

#  - platform: p1reader
#    p1reader_id: p1reader_esp
#    momentary_reactive_export_l3:
#      name: "Momentary Reactive Export Phase 3"

  - platform: p1reader
    p1reader_id: p1reader_esp
    voltage_l1:
      name: "Voltage Phase 1"
      id: U1

  - platform: p1reader
    p1reader_id: p1reader_esp
    voltage_l2:
      name: "Voltage Phase 2"
      id: U2

  - platform: p1reader
    p1reader_id: p1reader_esp
    voltage_l3:
      name: "Voltage Phase 3"
      id: U3

  - platform: p1reader
    p1reader_id: p1reader_esp
    current_l1:
      name: "Current Phase 1"
      id: I1

  - platform: p1reader
    p1reader_id: p1reader_esp
    current_l2:
      name: "Current Phase 2"
      id: I2

  - platform: p1reader
    p1reader_id: p1reader_esp
    current_l3:
      name: "Current Phase 3"
      id: I3
```
